### PR TITLE
Bump commons-text from 1.6 to 1.10.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-text</artifactId>
-            <version>1.6</version>
+            <version>1.10.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Bumps commons-text from 1.6 to 1.10.0.

---
updated-dependencies:
- dependency-name: org.apache.commons:commons-text dependency-type: direct:production ...

Signed-off-by: dependabot[bot] <support@github.com>